### PR TITLE
Fix null pointer when saving a new connection

### DIFF
--- a/src/main/java/com/exxeta/correomqtt/gui/controller/ConnectionSettingsViewController.java
+++ b/src/main/java/com/exxeta/correomqtt/gui/controller/ConnectionSettingsViewController.java
@@ -862,7 +862,10 @@ public class ConnectionSettingsViewController extends BaseController implements 
     }
 
     private void encodeLwtPayload(ConnectionPropertiesDTO c) {
-        c.getLwtPayloadProperty().set(Base64.getEncoder().encodeToString(c.getLwtPayload().getBytes()));
+        String lwtPayload = c.getLwtPayload();
+        if (lwtPayload != null) {
+            c.getLwtPayloadProperty().set(Base64.getEncoder().encodeToString(lwtPayload.getBytes()));
+        }
     }
 
     private boolean checkName(TextField textField, boolean save) {


### PR DESCRIPTION
Hi,

This is just a quick fix for an annoying null pointer exception when trying to save a new connection. It seems that otherwise it is impossible to save a new connection without LWT settings.

Kind regards, Dennis