### PR TITLE
Fix new version check

### DIFF
--- a/bump-version.bash
+++ b/bump-version.bash
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ $1 != v* ]] ; then
-  echo "Aborting: version must begin with a 'v'"
-  exit 1
-fi
 echo "set version to $1"
 mvn versions:set -DnewVersion="$1"
-echo -n "$1" > ./src/main/resources/org/correomqtt/business/utils/version.txt
+echo -n "v$1" > ./src/main/resources/org/correomqtt/business/utils/version.txt
 echo version.txt: $(cat ./src/main/resources/org/correomqtt/business/utils/version.txt)

--- a/bump-version.bash
+++ b/bump-version.bash
@@ -2,5 +2,5 @@
 
 echo "set version to $1"
 mvn versions:set -DnewVersion="$1"
-echo -n "v$1" > ./src/main/resources/org/correomqtt/business/utils/version.txt
+echo -n "$1" > ./src/main/resources/org/correomqtt/business/utils/version.txt
 echo version.txt: $(cat ./src/main/resources/org/correomqtt/business/utils/version.txt)

--- a/bump-version.bash
+++ b/bump-version.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [[ $1 != v* ]] ; then
+  echo "Aborting: version must begin with a 'v'"
+  exit 1
+fi
 echo "set version to $1"
 mvn versions:set -DnewVersion="$1"
 echo -n "$1" > ./src/main/resources/org/correomqtt/business/utils/version.txt

--- a/src/main/java/org/correomqtt/business/utils/VersionUtils.java
+++ b/src/main/java/org/correomqtt/business/utils/VersionUtils.java
@@ -62,9 +62,13 @@ public class VersionUtils {
                     new InputStreamReader(inputStream, StandardCharsets.UTF_8));
 
             ComparableVersion latestGithubVersion = new ComparableVersion(jsonObject.get("tag_name").toString());
-            ComparableVersion currentLocalVersion = new ComparableVersion(getVersion());
+            String localVersion = getVersion();
+            if (!localVersion.startsWith("v")) {
+                localVersion = "v" + localVersion;
+            }
+            ComparableVersion currentLocalVersion = new ComparableVersion(localVersion);
 
-            if (latestGithubVersion.compareTo(currentLocalVersion) == 1) {
+            if (latestGithubVersion.compareTo(currentLocalVersion) > 0) {
                 LOGGER.info("There is a new release available on github!");
                 return jsonObject.get("tag_name").toString();
             } else {

--- a/src/main/java/org/correomqtt/business/utils/VersionUtils.java
+++ b/src/main/java/org/correomqtt/business/utils/VersionUtils.java
@@ -61,12 +61,8 @@ public class VersionUtils {
             JSONObject jsonObject = (JSONObject)jsonParser.parse(
                     new InputStreamReader(inputStream, StandardCharsets.UTF_8));
 
-            ComparableVersion latestGithubVersion = new ComparableVersion(jsonObject.get("tag_name").toString());
-            String localVersion = getVersion();
-            if (!localVersion.startsWith("v")) {
-                localVersion = "v" + localVersion;
-            }
-            ComparableVersion currentLocalVersion = new ComparableVersion(localVersion);
+            ComparableVersion latestGithubVersion = new ComparableVersion(jsonObject.get("tag_name").toString().replaceAll("[^0-9\\.]",""));
+            ComparableVersion currentLocalVersion = new ComparableVersion(getVersion());
 
             if (latestGithubVersion.compareTo(currentLocalVersion) > 0) {
                 LOGGER.info("There is a new release available on github!");


### PR DESCRIPTION
- Modified the bump-version script to abort if no leading 'v' is added.
- Checks if the local version starts with a 'v', if not a 'v' is added right before the version comparison

Fixes #51 