### PR TITLE
Remove obsolete format function from detail view controller and update changes in AutoFormatPayload.java

### DIFF
--- a/src/main/java/org/correomqtt/business/utils/AutoFormatPayload.java
+++ b/src/main/java/org/correomqtt/business/utils/AutoFormatPayload.java
@@ -37,8 +37,13 @@ public class AutoFormatPayload {
             foundFormat = availableFormats.stream()
                     .filter(Objects::nonNull)
                     .filter(format -> {
-                                format.setText(payload);
-                                return format.isValid();
+                                try {
+                                    format.setText(payload);
+                                    return format.isValid();
+                                }catch(Exception e){
+                                    LOGGER.error("Formatting check failed. ",e);
+                                    return false;
+                                }
                             }
                     )
                     .findFirst()
@@ -54,8 +59,16 @@ public class AutoFormatPayload {
         }
 
         codeArea.clear();
-        codeArea.replaceText(0, 0, foundFormat.getPrettyString());
-        codeArea.setStyleSpans(0, foundFormat.getFxSpans());
+        try {
+            codeArea.replaceText(0, 0, foundFormat.getPrettyString());
+            codeArea.setStyleSpans(0, foundFormat.getFxSpans());
+        }catch(Exception e){
+            LOGGER.error("Formatter failed. ",e);
+            foundFormat = new Plain();
+            foundFormat.setText(payload);
+            codeArea.replaceText(0, 0, foundFormat.getPrettyString());
+            codeArea.setStyleSpans(0, foundFormat.getFxSpans());
+        }
 
         if (listener != null) {
             codeArea.textProperty().addListener(listener);

--- a/src/main/java/org/correomqtt/gui/controller/DetailViewController.java
+++ b/src/main/java/org/correomqtt/gui/controller/DetailViewController.java
@@ -472,50 +472,6 @@ public class DetailViewController extends BaseConnectionController implements
         MessageUtils.saveMessage(getConnectionId(), messageDTO, stage);
     }
 
-    private Format autoFormatPayload(final String payload, boolean doFormatting) {
-
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Auto formatting payload: {}", getConnectionId());
-        }
-
-        Format foundFormat;
-        if (doFormatting) {
-            // Find the first format that is valid.
-            ArrayList<Format> availableFormats = new ArrayList<>(PluginManager.getInstance().getExtensions(DetailViewFormatHook.class));
-            availableFormats.add(new Plain());
-            foundFormat = availableFormats.stream()
-                    .filter(Objects::nonNull)
-                    .filter(format -> {
-                                try {
-                                    format.setText(payload);
-                                    return format.isValid();
-                                }catch(Exception e){
-                                    LOGGER.error("Formatting check failed. ",e);
-                                    return false;
-                                }
-                            }
-                    )
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("Plain format did not match."));
-        } else {
-            foundFormat = new Plain();
-            foundFormat.setText(payload);
-        }
-
-        codeArea.clear();
-        try {
-            codeArea.replaceText(0, 0, foundFormat.getPrettyString());
-            codeArea.setStyleSpans(0, foundFormat.getFxSpans());
-        }catch(Exception e){
-            LOGGER.error("Formatter failed. ",e);
-            foundFormat = new Plain();
-            foundFormat.setText(payload);
-            codeArea.replaceText(0, 0, foundFormat.getPrettyString());
-            codeArea.setStyleSpans(0, foundFormat.getFxSpans());
-        }
-        return foundFormat;
-    }
-
     private void showSearchResult() {
 
         currentSearchString = searchTextField.textProperty().get();


### PR DESCRIPTION
The format helper is used by the detail view controller and also by the publish view controller for formatting the code area. I forgot to remove the obsolete code from the detail view controller with #64. But the new helper class was already used in the detail view controller, just forgot to remove the function.

I added your changes from #75, do you agree with that @farion?