### PR TITLE
Toggle scrolling#130

### DIFF
--- a/gui/src/main/java/org/correomqtt/gui/views/connections/MessageListViewController.java
+++ b/gui/src/main/java/org/correomqtt/gui/views/connections/MessageListViewController.java
@@ -434,7 +434,6 @@ public class MessageListViewController extends BaseConnectionController implemen
 
     @FXML
     private void toggleAutomaticScrolling() {
-        LOGGER.info("toggleAutomaticScrolling");
         if (automaticScrollButton.isSelected()) {
             enableAutomaticScrolling();
         } else {
@@ -499,7 +498,6 @@ public class MessageListViewController extends BaseConnectionController implemen
 
             if (!isUserScrolling) {
                 isUserScrolling = true;
-                System.out.println("User started scrolling via mouse wheel");
                 // Reset the scrolling state after a delay
                 pause.playFromStart();
                 disableAutomaticScrolling();
@@ -533,7 +531,6 @@ public class MessageListViewController extends BaseConnectionController implemen
         public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
             if (!isUserScrolling) {
                 isUserScrolling = true;
-                System.out.println("User started scrolling via scrollbar");
                 pause.playFromStart();
                 disableAutomaticScrolling();
             }

--- a/gui/src/main/resources/org/correomqtt/gui/views/connections/messageListView.fxml
+++ b/gui/src/main/resources/org/correomqtt/gui/views/connections/messageListView.fxml
@@ -89,7 +89,7 @@
                     </HBox.margin>
                 </IconToggleButton>
             </HBox>
-            <ListView fx:id="listView" styleClass="noBorder" VBox.vgrow="ALWAYS" onMousePressed="#disableScrolling" onScroll="#disableScrolling">
+            <ListView fx:id="listView" styleClass="noBorder" VBox.vgrow="ALWAYS">
             </ListView>
         </VBox>
     </SplitPane>

--- a/gui/src/main/resources/org/correomqtt/gui/views/connections/messageListView.fxml
+++ b/gui/src/main/resources/org/correomqtt/gui/views/connections/messageListView.fxml
@@ -34,7 +34,7 @@
                     </HBox.margin>
                 </IconButton>
                 <IconButton fx:id="showDetailsButton" minHeight="25.0" minWidth="30.0" mnemonicParsing="false"
-                        onAction="#showDetailsOfMessage" icon="mdi-open-in-new">
+                            onAction="#showDetailsOfMessage" icon="mdi-open-in-new">
                     <tooltip>
                         <Tooltip text="%messageListViewShowDetailsTooltip"/>
                     </tooltip>
@@ -43,7 +43,7 @@
 
 
                 <IconButton fx:id="clearMessagesButton" minHeight="25.0" minWidth="30.0" mnemonicParsing="false"
-                        onAction="#clearList" icon="mdi-trash-can">
+                            onAction="#clearList" icon="mdi-trash-can">
                     <tooltip>
                         <Tooltip text="%messageListViewClearMessagesButton"/>
                     </tooltip>
@@ -58,12 +58,13 @@
                     </tooltip>
                     <items>
                         <IconCheckMenuItem fx:id="changeDisplayRetained" mnemonicParsing="false"
-                                       onAction="#changeRetainDisplay" styleClass="menuItem" text="%retainedMenuItem"/>
+                                           onAction="#changeRetainDisplay" styleClass="menuItem"
+                                           text="%retainedMenuItem"/>
                         <IconCheckMenuItem fx:id="changeDisplayQos" mnemonicParsing="false" onAction="#changeQosDisplay"
-                                       styleClass="menuItem" text="%qosMenuItem"/>
+                                           styleClass="menuItem" text="%qosMenuItem"/>
                         <IconCheckMenuItem fx:id="changeDisplayTimestamp" mnemonicParsing="false"
-                                  onAction="#changeTimestampDisplay" styleClass="menuItem"
-                                  text="%timestampMenuItem"/>
+                                           onAction="#changeTimestampDisplay" styleClass="menuItem"
+                                           text="%timestampMenuItem"/>
                     </items>
                     <HBox.margin>
                         <Insets left="5.0"/>
@@ -78,8 +79,17 @@
                         <Insets left="5.0"/>
                     </HBox.margin>
                 </IconToggleButton>
+                <IconToggleButton fx:id="automaticScrollButton" minHeight="25.0" minWidth="30.0" mnemonicParsing="false"
+                                  onAction="#toggleAutomaticScrolling" icon="mdi-mouse-scroll-wheel">
+                    <tooltip>
+                        <Tooltip text="%automaticScrollingTooltip"/>
+                    </tooltip>
+                    <HBox.margin>
+                        <Insets left="5.0"/>
+                    </HBox.margin>
+                </IconToggleButton>
             </HBox>
-            <ListView fx:id="listView" styleClass="noBorder" VBox.vgrow="ALWAYS">
+            <ListView fx:id="listView" styleClass="noBorder" VBox.vgrow="ALWAYS" onMousePressed="#disableScrolling" onScroll="#disableScrolling">
             </ListView>
         </VBox>
     </SplitPane>

--- a/gui/src/main/resources/org/correomqtt/i18n_de_DE.properties
+++ b/gui/src/main/resources/org/correomqtt/i18n_de_DE.properties
@@ -390,3 +390,4 @@ scriptingUnsavedCheckDescription=Es gibt ungespeicherte Änderungen. Möchten Si
 scriptingViewResetButtonTooltip=Änderungen verwerfen
 scriptingViewClearExecutionsButtonTooltip=Ausführungslogs löschen
 scriptingHelpLink=Learn how scripting works here.
+automaticScrollingTooltip=Automatisches Scrolling aktivieren

--- a/gui/src/main/resources/org/correomqtt/i18n_en_US.properties
+++ b/gui/src/main/resources/org/correomqtt/i18n_en_US.properties
@@ -389,3 +389,4 @@ scriptingUnsavedCheckDescription=There are unsaved changes. Do you really want t
 scriptingViewResetButtonTooltip=Revert changes
 scriptingViewClearExecutionsButtonTooltip=Remove Execution Logs
 scriptingHelpLink=Learn how scripting works here.
+automaticScrollingTooltip=Toggle automatic scrolling


### PR DESCRIPTION
# Description

Adds a toggle to enable/disable automatic scrolling. (default enabled)
Adds custom scroll listeners, that interact with the toggle:
* Scrolling per se disables automatic scrolling to the top
* Scrolling to top enables automatic scrolling to the top (in other words: resets to the default)

Fixes # 130

## Type of change

- [X ] New Feature (non-breaking change to add a feature)
# How to test

Please describe steps to test your change.

- [ ] Do subscribe to #
- [ ] Send a message to xyz with payload a
- [ ] repeat the step before untill listview appears full
- [ ] Send a message to xyz with payload b. validate default: message b is shown on top, others are down beneith
- [ ] click on one of the messages with a. validate the toggle for automatic scrolling switched automatically to disabled
- [ ] Send more messages: validate the clicked message stays on top
- [ ] Scroll down.
- [ ] Send more message: validate the clicked message is now on top again.
- [ ] Scroll to the far top: validate the  toggle for automatic scrolling switched automatically to enabled
- [ ] Send another message eg. with payload c. validate the new message stays on top (default)
- [ ] Also test behavior by actively pressing the toggle.

# Checklist:

- [ ] Code follows the coding guidelines
- [ ] Code is understandable by others
- [ ] Code is commented
- [ ] Migration of local user data is included (if relevant)
- [ ] No unexpected warnings or exceptions are thrown.
- [ ] Plugin compatibility is checked (if relevant)
- [ ] Unit Tests are added